### PR TITLE
Exempt Dependabot Pull Requests from Stale Bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,8 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
 daysUntilStale: 30
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - dependencies


### PR DESCRIPTION
Stale bot should not close pull requests created by Dependabot.
