### PR TITLE
Dismiss stale reviews with new commits

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,7 +26,7 @@ branches:
   protection:
     required_pull_request_reviews:
       required_approving_review_count: 1
-      dismiss_stale_reviews: false
+      dismiss_stale_reviews: true
       require_code_owner_reviews: false
       dismissal_restrictions:
         users: []


### PR DESCRIPTION
Currently new commits will not invalidate the approved state. This can be helpful for merging unrelated changes, but has the unfortunate side effect of letting a lot of changes through after review. This was especially noticeable if a force-push was done on a branch. The review stays, but the force-push changes the git history that was reviewed.